### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn flood_segmentation(path:&Path,width:usize,height:usize,symbols:&mut Vec<Vec<u
         scaled_image.save(path).unwrap();
     }
     //Export bounds
-    let bounds_str = String::from(format!("{:.?}",bounds));
+    let bounds_str = String::from(format!("{:?}",bounds));
     fs::write("splitInfo.txt",bounds_str).unwrap();
     println!("{} : Flood segmented",time(start));
 


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.